### PR TITLE
Pin socket.io-client version

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,7 +1,7 @@
 import React from "https://cdn.skypack.dev/react";
 import ReactDOM from "https://cdn.skypack.dev/react-dom";
 import * as Immer from "https://cdn.skypack.dev/immer";
-import io from "https://cdn.skypack.dev/socket.io-client";
+import io from "https://cdn.skypack.dev/socket.io-client@v4.0.1";
 
 import Buttons from './Buttons.js';
 import Board from './Board.js';


### PR DESCRIPTION
The latest version is broken (on skypack?).

More in general I think there should be a way to use the version from the server-side package.json, and then pin that, but I don't understand enough about Javascript tooling to do that :)